### PR TITLE
Add MCP health checks and proxy logging integration

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -618,5 +618,186 @@ class MCPServerManager:
             if get_builtin_registry().is_builtin_available(name)
         ]
 
+    async def health_check_server(self, server_id: str, mcp_auth_header: Optional[str] = None) -> Dict[str, Any]:
+        """Perform a health check on a specific MCP server."""
+        import time
+        from datetime import datetime
+
+        server = self.get_mcp_server_by_id(server_id)
+        if not server:
+            return {
+                "server_id": server_id,
+                "status": "unknown",
+                "error": "Server not found",
+                "last_health_check": datetime.now().isoformat(),
+                "response_time_ms": None,
+            }
+
+        start_time = time.time()
+        try:
+            tools = await self._get_tools_from_server(server, mcp_auth_header)
+            response_time = (time.time() - start_time) * 1000
+
+            return {
+                "server_id": server_id,
+                "status": "healthy",
+                "tools_count": len(tools),
+                "last_health_check": datetime.now().isoformat(),
+                "response_time_ms": round(response_time, 2),
+                "error": None,
+            }
+        except Exception as e:
+            response_time = (time.time() - start_time) * 1000
+            error_message = str(e)
+
+            return {
+                "server_id": server_id,
+                "status": "unhealthy",
+                "last_health_check": datetime.now().isoformat(),
+                "response_time_ms": round(response_time, 2),
+                "error": error_message,
+            }
+
+    async def health_check_all_servers(self, mcp_auth_header: Optional[str] = None) -> Dict[str, Any]:
+        """Perform health checks on all MCP servers."""
+        all_servers = self.get_registry()
+        results: Dict[str, Any] = {}
+
+        for server_id, _server in all_servers.items():
+            results[server_id] = await self.health_check_server(server_id, mcp_auth_header)
+
+        return results
+
+    async def health_check_allowed_servers(
+        self,
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+        mcp_auth_header: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Perform health checks on all MCP servers the user has access to."""
+        allowed_server_ids = await self.get_allowed_mcp_servers(user_api_key_auth)
+
+        results: Dict[str, Any] = {}
+        for server_id in allowed_server_ids:
+            results[server_id] = await self.health_check_server(server_id, mcp_auth_header)
+
+        return results
+
+    async def get_all_mcp_servers_with_health_and_teams(
+        self,
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+        include_health: bool = True,
+    ) -> List[LiteLLM_MCPServerTable]:
+        """Get all MCP servers accessible to the user with health + team info."""
+        from litellm.proxy.proxy_server import prisma_client
+        from litellm.proxy.management_endpoints.common_utils import _user_has_admin_view
+        from litellm.proxy._experimental.mcp_server.db import (
+            get_all_mcp_servers,
+            get_mcp_servers,
+        )
+
+        allowed_server_ids = await self.get_allowed_mcp_servers(user_api_key_auth)
+
+        list_mcp_servers: List[LiteLLM_MCPServerTable] = []
+        if prisma_client is not None:
+            list_mcp_servers = await get_mcp_servers(prisma_client, allowed_server_ids)
+
+            if user_api_key_auth and _user_has_admin_view(user_api_key_auth):
+                all_mcp_servers = await get_all_mcp_servers(prisma_client)
+                for server in all_mcp_servers:
+                    if server.server_id not in allowed_server_ids:
+                        list_mcp_servers.append(server)
+
+        for _server_id, _server_config in self.config_mcp_servers.items():
+            if _server_id in allowed_server_ids:
+                list_mcp_servers.append(
+                    LiteLLM_MCPServerTable(
+                        server_id=_server_id,
+                        server_name=_server_config.name,
+                        alias=_server_config.alias,
+                        url=_server_config.url,
+                        transport=_server_config.transport,
+                        spec_version=_server_config.spec_version,
+                        auth_type=_server_config.auth_type,
+                        created_at=datetime.datetime.now(),
+                        updated_at=datetime.datetime.now(),
+                        mcp_info=_server_config.mcp_info,
+                        command=getattr(_server_config, "command", None),
+                        args=getattr(_server_config, "args", None) or [],
+                        env=getattr(_server_config, "env", None) or {},
+                    )
+                )
+
+        server_to_teams_map: Dict[str, List[Dict[str, str]]] = {}
+        if user_api_key_auth and not _user_has_admin_view(user_api_key_auth) and prisma_client is not None:
+            teams = await prisma_client.db.litellm_teamtable.find_many(
+                include={"object_permission": True}
+            )
+
+            user_teams = []
+            for team in teams:
+                if team.members_with_roles:
+                    for member in team.members_with_roles:
+                        if (
+                            "user_id" in member
+                            and member["user_id"] is not None
+                            and member["user_id"] == user_api_key_auth.user_id
+                        ):
+                            user_teams.append(team)
+
+            for team in user_teams:
+                if team.object_permission and team.object_permission.mcp_servers:
+                    for server_id in team.object_permission.mcp_servers:
+                        if server_id not in server_to_teams_map:
+                            server_to_teams_map[server_id] = []
+                        server_to_teams_map[server_id].append(
+                            {
+                                "team_id": team.team_id,
+                                "team_alias": team.team_alias,
+                                "organization_id": team.organization_id,
+                            }
+                        )
+
+        all_health_results: Dict[str, Any] = {}
+        if include_health:
+            try:
+                all_health_results = await self.health_check_allowed_servers(user_api_key_auth)
+            except Exception as e:
+                verbose_logger.debug(f"Error performing health checks: {e}")
+
+        from typing import cast
+
+        return [
+            LiteLLM_MCPServerTable(
+                server_id=server.server_id,
+                server_name=server.server_name,
+                alias=server.alias,
+                description=server.description,
+                url=server.url,
+                transport=server.transport,
+                spec_version=server.spec_version,
+                auth_type=server.auth_type,
+                created_at=server.created_at,
+                created_by=server.created_by,
+                updated_at=server.updated_at,
+                updated_by=server.updated_by,
+                mcp_access_groups=server.mcp_access_groups if server.mcp_access_groups is not None else [],
+                mcp_info=server.mcp_info,
+                teams=cast(List[Dict[str, str | None]], server_to_teams_map.get(server.server_id, [])),
+                status=all_health_results.get(server.server_id, {}).get("status", "unknown"),
+                last_health_check=datetime.datetime.fromisoformat(
+                    all_health_results.get(server.server_id, {}).get(
+                        "last_health_check", datetime.datetime.now().isoformat()
+                    )
+                )
+                if all_health_results.get(server.server_id, {}).get("last_health_check")
+                else None,
+                health_check_error=all_health_results.get(server.server_id, {}).get("error"),
+                command=getattr(server, "command", None),
+                args=getattr(server, "args", None) or [],
+                env=getattr(server, "env", None) or {},
+            )
+            for server in list_mcp_servers
+        ]
+
 
 global_mcp_server_manager: MCPServerManager = MCPServerManager()

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -381,10 +381,14 @@ class LiteLLM_Proxy_MCP_Handler:
                 # Execute the tool
                 parsed_arguments = LiteLLM_Proxy_MCP_Handler._parse_tool_arguments(tool_arguments)
 
+                # Import here to avoid circular import
+                from litellm.proxy.proxy_server import proxy_logging_obj
+
                 result = await global_mcp_server_manager.call_tool(
                     name=tool_name,
                     arguments=parsed_arguments,
                     user_api_key_auth=user_api_key_auth,
+                    proxy_logging_obj=proxy_logging_obj,
                 )
 
                 # Format result
@@ -523,10 +527,14 @@ class LiteLLM_Proxy_MCP_Handler:
 
                 parsed_arguments = LiteLLM_Proxy_MCP_Handler._parse_tool_arguments(tool_arguments)
 
+                # Import here to avoid circular import
+                from litellm.proxy.proxy_server import proxy_logging_obj
+
                 result = await global_mcp_server_manager.call_tool(
                     name=tool_name,
                     arguments=parsed_arguments,
                     user_api_key_auth=user_api_key_auth,
+                    proxy_logging_obj=proxy_logging_obj,
                 )
 
                 # Format result for inclusion in response


### PR DESCRIPTION
## Summary
- add MCP server health check helpers and listing with team visibility
- pass proxy_logging_obj when executing MCP tools

## Testing
- `pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_688b64fba9c0832a9f8a5fdeb1155336